### PR TITLE
Agda 2.6 fixes (not everything)

### DIFF
--- a/LTL.agda
+++ b/LTL.agda
@@ -4,14 +4,12 @@ open import NeilPrelude
 open import Logic
 
 module LTL
-
   (Time    : Set)
-  (initial   : Time)
-  (_≤_    : Rel Time)
+  (initial : Time)
+  (_≤_     : Rel Time)
   (reflex  : Reflexive _≤_)
   (transit : Transitive _≤_)
-
-where
+  where
 
 -------------------------------
 

--- a/NeilPrelude.agda
+++ b/NeilPrelude.agda
@@ -86,7 +86,6 @@ data _≡_ {A : Set} (a : A) : A → Set where
   refl : a ≡ a 
 
 {-# BUILTIN EQUALITY _≡_ #-}
-{-# BUILTIN REFL refl #-}
 
 Eq : (A : Set) → Rel A
 Eq A = _≡_ {A}


### PR DESCRIPTION
* `BUILTIN REFL` seems to be removed in 2.6 (https://agda.readthedocs.io/en/v2.6.0.1/language/built-ins.html#equality)
* The parameterized module caused a parse error, needed indentation